### PR TITLE
Set Description on Microsoft.Extensions.Http

### DIFF
--- a/src/Microsoft.Extensions.Http/Microsoft.Extensions.Http.csproj
+++ b/src/Microsoft.Extensions.Http/Microsoft.Extensions.Http.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Provides API for creating HttpClient instances.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Required to unblock moving forward to the 2.1. NuGet [used to set this property](https://github.com/NuGet/NuGet.Client/pull/1648) by default in all projects, causing a false-positive test pass on from the NuGetPackageVerifier. They fixed this...which means our build will actually fail when this isn't set.

cref https://github.com/aspnet/BuildTools/pull/457