### PR TITLE
Add a description

### DIFF
--- a/src/Microsoft.Extensions.Http/Microsoft.Extensions.Http.csproj
+++ b/src/Microsoft.Extensions.Http/Microsoft.Extensions.Http.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Provides API for creating HttpClient instances.</Description>
+    <Description>
+      The HttpClient factory is a pattern for configuring and retrieving named HttpClients in a composable way. The HttpClient factory provides extensibility to plug in DelegatingHandlers that address cross-cutting concerns such as service location, load balancing, and reliability. The default HttpClient factory provides built-in diagnostics and logging and manages the lifetimes of connections in a performant way.
+      Commonly used types:
+      System.Net.Http.IHttpClientFactory
+    </Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
@glennc @Eilon 
```
      The HttpClient factory is a pattern for configuring and retrieving named HttpClients in a composable way. The HttpClient factory
provides extensibility to plug in DelegatingHandlers that address cross-cutting concerns such as service location, load balancing,
and reliability. The default HttpClient factory provides built-in diagnostics and logging and manages the lifetimes of 
connections in a performant way.
      Commonly used types:
      System.Net.Http.IHttpClientFactory
```