### PR TITLE
Add two basic microbenchmarks

### DIFF
--- a/HttpClientFactory.sln
+++ b/HttpClientFactory.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2008
+VisualStudioVersion = 15.0.27025.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0ACA47C2-6B67-46B8-A661-C564E4450DE4}"
 EndProject
@@ -14,6 +14,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{FF6B150F-C423-41BB-9563-55A0DFEAE21C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HttpClientFactorySample", "samples\HttpClientFactorySample\HttpClientFactorySample.csproj", "{42C81623-6316-4C15-9E41-84AF48608C47}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{BAD8867C-73F7-4DB8-8E79-70287E67987A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Http.Performance", "benchmarks\Microsoft.Extensions.Http.Performance\Microsoft.Extensions.Http.Performance.csproj", "{0A0C4C1A-3A07-43C1-8A74-4DE193D50939}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{EBF25046-7C9B-4F84-ACEA-E836012F4459}"
 	ProjectSection(SolutionItems) = preProject
@@ -39,6 +43,10 @@ Global
 		{42C81623-6316-4C15-9E41-84AF48608C47}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{42C81623-6316-4C15-9E41-84AF48608C47}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{42C81623-6316-4C15-9E41-84AF48608C47}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A0C4C1A-3A07-43C1-8A74-4DE193D50939}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A0C4C1A-3A07-43C1-8A74-4DE193D50939}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A0C4C1A-3A07-43C1-8A74-4DE193D50939}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A0C4C1A-3A07-43C1-8A74-4DE193D50939}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -47,6 +55,7 @@ Global
 		{99E3492F-87BB-4506-8D2B-D1C7101655DC} = {0ACA47C2-6B67-46B8-A661-C564E4450DE4}
 		{752F6163-AE48-46D3-8A6D-695BBF3629CB} = {A7C2238C-5C0F-4D33-BE66-4015985CE962}
 		{42C81623-6316-4C15-9E41-84AF48608C47} = {FF6B150F-C423-41BB-9563-55A0DFEAE21C}
+		{0A0C4C1A-3A07-43C1-8A74-4DE193D50939} = {BAD8867C-73F7-4DB8-8E79-70287E67987A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {002C7A25-D737-4B87-AFBB-B6E0FB2DB0D3}

--- a/benchmarks/Microsoft.Extensions.Http.Performance/Configs/CoreConfig.cs
+++ b/benchmarks/Microsoft.Extensions.Http.Performance/Configs/CoreConfig.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Validators;
+
+namespace Microsoft.Extensions.Http.Performance
+{
+    public class CoreConfig : ManualConfig
+    {
+        public CoreConfig() 
+            : this(Job.Core
+                .WithRemoveOutliers(false)
+                .With(new GcMode() { Server = true })
+                .With(RunStrategy.Throughput)
+                .WithLaunchCount(3)
+                .WithWarmupCount(5)
+                .WithTargetCount(10))
+        {
+            Add(JitOptimizationsValidator.FailOnError);
+        }
+
+        public CoreConfig(Job job)
+        {
+            Add(DefaultConfig.Instance);
+
+            Add(MemoryDiagnoser.Default);
+            Add(StatisticColumn.OperationsPerSecond);
+
+            Add(job);
+        }
+    }
+}

--- a/benchmarks/Microsoft.Extensions.Http.Performance/CreationOverheadBenchmark.cs
+++ b/benchmarks/Microsoft.Extensions.Http.Performance/CreationOverheadBenchmark.cs
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.Http.Performance
+{
+    [ParameterizedJobConfig(typeof(CoreConfig))]
+    public class CreationOverheadBenchmark
+    {
+        private const int Iterations = 100;
+
+        public CreationOverheadBenchmark()
+        {
+            Handler = new FakeClientHandler();
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.Configure<HttpClientFactoryOptions>("example", options =>
+            {
+                options.HttpMessageHandlerBuilderActions.Add(b => b.PrimaryHandler = Handler);
+            });
+            serviceCollection.AddHttpClient("example", c =>
+            {
+                c.BaseAddress = new Uri("http://example.com/");
+                c.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            });
+
+            var services = serviceCollection.BuildServiceProvider();
+            Factory = services.GetRequiredService<IHttpClientFactory>();
+        }
+
+        public IHttpClientFactory Factory { get; }
+
+        public HttpMessageHandler Handler { get; }
+
+        [Benchmark(
+            Description = "use IHttpClientFactory", 
+            OperationsPerInvoke = Iterations)]
+        public async Task CreateClient()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                var client = Factory.CreateClient("example");
+
+                var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "api/Products"));
+                response.EnsureSuccessStatusCode();
+            }
+        }
+
+        [Benchmark(
+            Description = "new HttpClient",
+            Baseline = true,
+            OperationsPerInvoke = Iterations)]
+        public async Task Baseline()
+        {
+            for (var i = 0; i < Iterations; i++)
+            {
+                var client = new HttpClient(Handler, disposeHandler: false)
+                {
+                    BaseAddress = new Uri("http://example.com/"),
+                    DefaultRequestHeaders =
+                    {
+                        Accept =
+                        {
+                            new MediaTypeWithQualityHeaderValue("application/json"),
+                        }
+                    },
+                };
+
+                var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "api/Products"));
+                response.EnsureSuccessStatusCode();
+            }
+        }
+    }
+}

--- a/benchmarks/Microsoft.Extensions.Http.Performance/FakeClientHandler.cs
+++ b/benchmarks/Microsoft.Extensions.Http.Performance/FakeClientHandler.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.Http.Performance
+{
+    internal class FakeClientHandler : HttpMessageHandler
+    {
+        public TimeSpan Latency { get; set; } = TimeSpan.FromMilliseconds(10);
+
+        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.RequestMessage = request;
+            return response;
+        }
+    }
+}

--- a/benchmarks/Microsoft.Extensions.Http.Performance/FakeLoggerProvider.cs
+++ b/benchmarks/Microsoft.Extensions.Http.Performance/FakeLoggerProvider.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Http.Performance
+{
+    internal class FakeLoggerProvider : ILoggerProvider
+    {
+        public bool IsEnabled { get; set; }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new Logger(this);
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private class Logger : ILogger
+        {
+            private FakeLoggerProvider _provider;
+
+            public Logger(FakeLoggerProvider provider)
+            {
+                _provider = provider;
+            }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                return null;
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return _provider.IsEnabled;
+            }
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+            }
+        }
+    }
+}

--- a/benchmarks/Microsoft.Extensions.Http.Performance/LoggingOverheadBenchmark.cs
+++ b/benchmarks/Microsoft.Extensions.Http.Performance/LoggingOverheadBenchmark.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Http.Performance
+{
+    [ParameterizedJobConfig(typeof(CoreConfig))]
+    public class LoggingOverheadBenchmark
+    {
+        private const int Iterations = 100;
+
+        public LoggingOverheadBenchmark()
+        {
+            Handler = new FakeClientHandler();
+            LoggerProvider = new FakeLoggerProvider();
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging(b => b.AddProvider(LoggerProvider));
+            serviceCollection.Configure<HttpClientFactoryOptions>("example", options =>
+            {
+                options.HttpMessageHandlerBuilderActions.Add(b => b.PrimaryHandler = Handler);
+            });
+            serviceCollection.AddHttpClient("example", c =>
+            {
+                c.BaseAddress = new Uri("http://example.com/");
+                c.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            });
+
+            var services = serviceCollection.BuildServiceProvider();
+            Factory = services.GetRequiredService<IHttpClientFactory>();
+        }
+
+        private IHttpClientFactory Factory { get; }
+
+        private HttpMessageHandler Handler { get; }
+
+        private FakeLoggerProvider LoggerProvider { get; }
+
+        [Benchmark(
+            Description = "logging on", 
+            OperationsPerInvoke = Iterations)]
+        public async Task LoggingOn()
+        {
+            LoggerProvider.IsEnabled = true;
+
+            for (var i = 0; i < Iterations; i++)
+            {
+                var client = Factory.CreateClient("example");
+
+                var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "api/Products"));
+                response.EnsureSuccessStatusCode();
+            }
+        }
+
+        [Benchmark(
+            Description = "logging off",
+            OperationsPerInvoke = Iterations)]
+        public async Task LoggingOff()
+        {
+            LoggerProvider.IsEnabled = false;
+
+            for (var i = 0; i < Iterations; i++)
+            {
+                var client = Factory.CreateClient("example");
+
+                var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "api/Products"));
+                response.EnsureSuccessStatusCode();
+            }
+        }
+    }
+}

--- a/benchmarks/Microsoft.Extensions.Http.Performance/Microsoft.Extensions.Http.Performance.csproj
+++ b/benchmarks/Microsoft.Extensions.Http.Performance/Microsoft.Extensions.Http.Performance.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Extensions.Http\Microsoft.Extensions.Http.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" PrivateAssets="All" Version="$(MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion)" />
+  </ItemGroup>
+
+</Project>
+

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,9 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
+    <BenchmarkDotNetPackageVersion>0.10.9</BenchmarkDotNetPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15576</InternalAspNetCoreSdkPackageVersion>
+    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>2.1.0-preview1-27475</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftAspNetWebApiClientPackageVersion>5.2.2</MicrosoftAspNetWebApiClientPackageVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.1.0-preview1-27644</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>


### PR DESCRIPTION
- Overhead of using the factory vs new HttpClient
- Overhead of our logging system (logger on vs off)

These are fairly simple right now and don't attempt to simulate a real
request going over the wire nor a real logging system. This makes them
'worst case' for examining our overhead.

So far what I see seems pretty good.