### PR TITLE
Replace hard-coded strings in EventIds class

### DIFF
--- a/src/Microsoft.Extensions.Http/Logging/LoggingHttpMessageHandler.cs
+++ b/src/Microsoft.Extensions.Http/Logging/LoggingHttpMessageHandler.cs
@@ -48,11 +48,11 @@ namespace Microsoft.Extensions.Http.Logging
         {
             public static class EventIds
             {
-                public static readonly EventId RequestStart = new EventId(100, "RequestStart");
-                public static readonly EventId RequestEnd = new EventId(101, "RequestEnd");
+                public static readonly EventId RequestStart = new EventId(100, nameof(RequestStart));
+                public static readonly EventId RequestEnd = new EventId(101, nameof(RequestEnd));
 
-                public static readonly EventId RequestHeader = new EventId(102, "RequestHeader");
-                public static readonly EventId ResponseHeader = new EventId(103, "ResponseHeader");
+                public static readonly EventId RequestHeader = new EventId(102, nameof(RequestHeader));
+                public static readonly EventId ResponseHeader = new EventId(103, nameof(ResponseHeader));
             }
 
             private static readonly Action<ILogger, HttpMethod, Uri, Exception> _requestStart = LoggerMessage.Define<HttpMethod, Uri>(


### PR DESCRIPTION
Make use of C#'s `nameof` operator to replace some hard-coded string values in the `EventIds` class.