### PR TITLE
Allowing Timeout.InfiniteTimeSpan for HandlerLifeTime

### DIFF
--- a/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientBuilderExtensions.cs
@@ -451,7 +451,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            if (handlerLifetime < HttpClientFactoryOptions.MinimumHandlerLifetime)
+            if (handlerLifetime != Timeout.InfiniteTimeSpan && handlerLifetime < HttpClientFactoryOptions.MinimumHandlerLifetime)
             {
                 throw new ArgumentException(Resources.HandlerLifetime_InvalidValue, nameof(handlerLifetime));
             }

--- a/src/Microsoft.Extensions.Http/HttpClientFactoryOptions.cs
+++ b/src/Microsoft.Extensions.Http/HttpClientFactoryOptions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.Http
             get => _handlerLifetime;
             set
             {
-                if (value < MinimumHandlerLifetime)
+                if (value != Timeout.InfiniteTimeSpan && value < MinimumHandlerLifetime)
                 {
                     throw new ArgumentException(Resources.HandlerLifetime_InvalidValue, nameof(value));
                 }


### PR DESCRIPTION
Fixes #50

Also updated the setter on HttpClientFactoryOptions.HandlerLifetime

@rynowak I happened to be perusing the code and the latest issues. Thought I'd throw this out there so see if it's what you intended?

The ActiveHandlerTrackingEntry will never expire if the LifeTime is set to InfiniteTimeSpan.