### PR TITLE
Refine test AddPolicyHandler_Generic_AddsPolicyHandler

### DIFF
--- a/test/Microsoft.Extensions.Http.Polly.Test/DependencyInjection/PollyHttpClientBuilderExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Http.Polly.Test/DependencyInjection/PollyHttpClientBuilderExtensionsTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // Act1
             serviceCollection.AddHttpClient("example.com")
-                .AddPolicyHandler(Policy.TimeoutAsync(5))
+                .AddPolicyHandler(Policy.TimeoutAsync<HttpResponseMessage>(5))
                 .ConfigureHttpMessageHandlerBuilder(b =>
                 {
                     builder = b;


### PR DESCRIPTION
The test was identical to the nongeneric test above it.  From the test title, it looks as if the intention is to exercise the `AddPolicyHandler(this IHttpClientBuilder builder, IAsyncPolicy<HttpResponseMessage> policy)` generic method.  This change makes it do so.