### PR TITLE
Remove support for NonGeneric Polly policies from PolicyRegistry helper methods

### DIFF
--- a/src/Microsoft.Extensions.Http.Polly/DependencyInjection/PollyHttpClientBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.Http.Polly/DependencyInjection/PollyHttpClientBuilderExtensions.cs
@@ -99,13 +99,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 var registry = services.GetRequiredService<IReadOnlyPolicyRegistry<string>>();
 
-                // The policy might be either IAsyncPolicy or IAsyncPolicy<HttpRequestMessage> but never both.
-                // But, the handler expects IAsyncPolicy<HttpRequestMessage>, so try first for what we want and then
-                // fall back to the non-generic interface. We'll get the non-generic case throw the policy isn't registred.
-                if (!registry.TryGet<IAsyncPolicy<HttpResponseMessage>>(policyKey, out var policy))
-                {
-                    policy = registry.Get<IAsyncPolicy>(policyKey).WrapAsync(Policy.NoOpAsync<HttpResponseMessage>());
-                }
+                policy = registry.Get<IAsyncPolicy<HttpResponseMessage>>(policyKey);
 
                 return new PolicyHttpMessageHandler(policy);
             });

--- a/src/Microsoft.Extensions.Http.Polly/DependencyInjection/PollyHttpClientBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.Http.Polly/DependencyInjection/PollyHttpClientBuilderExtensions.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 var registry = services.GetRequiredService<IReadOnlyPolicyRegistry<string>>();
 
-                policy = registry.Get<IAsyncPolicy<HttpResponseMessage>>(policyKey);
+                var policy = registry.Get<IAsyncPolicy<HttpResponseMessage>>(policyKey);
 
                 return new PolicyHttpMessageHandler(policy);
             });


### PR DESCRIPTION
Removes support for NonGeneric Polly policies from `IHttpClientBuilder.AddPolicyHandlerFromRegistry(...)`

We decided that `HttpClientFactory` would not support Polly's non-generic policies `IAsyncPolicy` at this time.  This PR removes one left-over reference.