### PR TITLE
Update Polly dependency to v5.9.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -18,8 +18,8 @@
     <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview3-26331-01</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.7.49</MoqPackageVersion>
-    <PollySignedPackageVersion>5.8.0</PollySignedPackageVersion>
-    <PollyExtensionsHttpSignedPackageVersion>1.0.1-preview2</PollyExtensionsHttpSignedPackageVersion>
+    <PollySignedPackageVersion>5.9.0</PollySignedPackageVersion>
+    <PollyExtensionsHttpSignedPackageVersion>1.0.2-rc1</PollyExtensionsHttpSignedPackageVersion>
     <XunitAnalyzersPackageVersion>0.8.0</XunitAnalyzersPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0-beta.1.build3945</XunitRunnerVisualStudioPackageVersion>

--- a/src/Microsoft.Extensions.Http.Polly/PolicyHttpMessageHandler.cs
+++ b/src/Microsoft.Extensions.Http.Polly/PolicyHttpMessageHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.Http
     /// <example>
     /// Converting a non-generic <code>IAsyncPolicy policy</code> to <see cref="IAsyncPolicy{HttpResponseMessage}"/>.
     /// <code>
-    /// policy.WrapAsync(Policy.NoOpAsync&lt;HttpResponseMessage&gt;())
+    /// policy.AsAsyncPolicy&lt;HttpResponseMessage&gt;()
     /// </code>
     /// </example>
     /// </para>
@@ -117,7 +117,7 @@ namespace Microsoft.Extensions.Http
             var context = request.GetPolicyExecutionContext();
             if (context == null)
             {
-                context = new Context(null);
+                context = new Context();
                 request.SetPolicyExecutionContext(context);
             }
 


### PR DESCRIPTION
Update Polly dependency to v5.9.0
- Update Polly dependency
- Update corresponding Polly.Extensions.Http dependency
- Adopt Polly v5.9.0 usages within HttpClientFactory (no functional change)

Addresses #92 