### PR TITLE
Redesign ITypedClientFactory to be generic

### DIFF
--- a/src/Microsoft.Extensions.Http/DefaultTypedHttpClientFactory.cs
+++ b/src/Microsoft.Extensions.Http/DefaultTypedHttpClientFactory.cs
@@ -3,13 +3,19 @@
 
 using System;
 using System.Net.Http;
+using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Http
 {
-    internal class DefaultTypedHttpClientFactory : ITypedHttpClientFactory
+    internal class DefaultTypedHttpClientFactory<TClient> : ITypedHttpClientFactory<TClient>
     {
+        private readonly static Func<ObjectFactory> _createActivator = () => ActivatorUtilities.CreateFactory(typeof(TClient), new Type[] { typeof(HttpClient), });
         private readonly IServiceProvider _services;
+
+        private ObjectFactory _activator;
+        private bool _initialized;
+        private object _lock;
 
         public DefaultTypedHttpClientFactory(IServiceProvider services)
         {
@@ -21,14 +27,15 @@ namespace Microsoft.Extensions.Http
             _services = services;
         }
 
-        public TClient CreateClient<TClient>(HttpClient httpClient)
+        public TClient CreateClient(HttpClient httpClient)
         {
             if (httpClient == null)
             {
                 throw new ArgumentNullException(nameof(httpClient));
             }
 
-            return ActivatorUtilities.CreateInstance<TClient>(_services, httpClient);
+            LazyInitializer.EnsureInitialized(ref _activator, ref _initialized, ref _lock, _createActivator);
+            return (TClient)_activator(_services, new object[] { httpClient });
         }
     }
 }

--- a/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientBuilderExtensions.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TClient">
         /// The type of the typed client. They type specified will be registered in the service collection as
-        /// a transient service. See <see cref="ITypedHttpClientFactory" /> for more details about authoring typed clients.
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
         /// </typeparam>
         /// <param name="builder">The <see cref="IHttpClientBuilder"/>.</param>
         /// <remarks>
@@ -289,7 +289,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </para>
         /// <para>
         /// Calling <see cref="HttpClientBuilderExtensions.AddTypedClient{TClient}(IHttpClientBuilder)"/> will register a typed
-        /// client binding that creates <typeparamref name="TClient"/> using the <see cref="ITypedHttpClientFactory" />.
+        /// client binding that creates <typeparamref name="TClient"/> using the <see cref="ITypedHttpClientFactory{TClient}" />.
         /// </para>
         /// </remarks>
         public static IHttpClientBuilder AddTypedClient<TClient>(this IHttpClientBuilder builder)
@@ -305,8 +305,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();
                 var httpClient = httpClientFactory.CreateClient(builder.Name);
 
-                var typedClientFactory = s.GetRequiredService<ITypedHttpClientFactory>();
-                return typedClientFactory.CreateClient<TClient>(httpClient);
+                var typedClientFactory = s.GetRequiredService<ITypedHttpClientFactory<TClient>>();
+                return typedClientFactory.CreateClient(httpClient);
             });
 
             return builder;
@@ -319,11 +319,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TClient">
         /// The declared type of the typed client. They type specified will be registered in the service collection as
-        /// a transient service. See <see cref="ITypedHttpClientFactory" /> for more details about authoring typed clients.
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TImplementation}" /> for more details about authoring typed clients.
         /// </typeparam>
         /// <typeparam name="TImplementation">
         /// The implementation type of the typed client. The type specified by will be instantiated by the 
-        /// <see cref="ITypedHttpClientFactory"/>.
+        /// <see cref="ITypedHttpClientFactory{TImplementation}"/>.
         /// </typeparam>
         /// <param name="builder">The <see cref="IHttpClientBuilder"/>.</param>
         /// <remarks>
@@ -335,7 +335,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <para>
         /// Calling <see cref="HttpClientBuilderExtensions.AddTypedClient{TClient,TImplementation}(IHttpClientBuilder)"/>
         /// will register a typed client binding that creates <typeparamref name="TImplementation"/> using the 
-        /// <see cref="ITypedHttpClientFactory" />.
+        /// <see cref="ITypedHttpClientFactory{TImplementation}" />.
         /// </para>
         /// </remarks>
         public static IHttpClientBuilder AddTypedClient<TClient, TImplementation>(this IHttpClientBuilder builder)
@@ -352,8 +352,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();
                 var httpClient = httpClientFactory.CreateClient(builder.Name);
 
-                var typedClientFactory = s.GetRequiredService<ITypedHttpClientFactory>();
-                return typedClientFactory.CreateClient<TImplementation>(httpClient);
+                var typedClientFactory = s.GetRequiredService<ITypedHttpClientFactory<TImplementation>>();
+                return typedClientFactory.CreateClient(httpClient);
             });
 
             return builder;

--- a/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection
             //
             // Typed Clients
             //
-            services.TryAddSingleton<ITypedHttpClientFactory, DefaultTypedHttpClientFactory>();
+            services.TryAdd(ServiceDescriptor.Singleton(typeof(ITypedHttpClientFactory<>), typeof(DefaultTypedHttpClientFactory<>)));
 
             //
             // Misc infrastructure
@@ -169,7 +169,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TClient">
         /// The type of the typed client. They type specified will be registered in the service collection as
-        /// a transient service. See <see cref="ITypedHttpClientFactory" /> for more details about authoring typed clients.
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
         /// </typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>An <see cref="IHttpClientBuilder"/> that can be used to configure the client.</returns>
@@ -209,11 +209,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TClient">
         /// The type of the typed client. They type specified will be registered in the service collection as
-        /// a transient service. See <see cref="ITypedHttpClientFactory" /> for more details about authoring typed clients.
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
         /// </typeparam>
         /// <typeparam name="TImplementation">
         /// The implementation type of the typed client. They type specified will be instantiated by the
-        /// <see cref="ITypedHttpClientFactory"/>
+        /// <see cref="ITypedHttpClientFactory{TImplementation}"/>
         /// </typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>An <see cref="IHttpClientBuilder"/> that can be used to configure the client.</returns>
@@ -250,7 +250,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TClient">
         /// The type of the typed client. They type specified will be registered in the service collection as
-        /// a transient service. See <see cref="ITypedHttpClientFactory" /> for more details about authoring typed clients.
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
         /// </typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>
@@ -296,11 +296,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TClient">
         /// The type of the typed client. They type specified will be registered in the service collection as
-        /// a transient service. See <see cref="ITypedHttpClientFactory" /> for more details about authoring typed clients.
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
         /// </typeparam>
         /// <typeparam name="TImplementation">
         /// The implementation type of the typed client. They type specified will be instantiated by the
-        /// <see cref="ITypedHttpClientFactory"/>
+        /// <see cref="ITypedHttpClientFactory{TImplementation}"/>
         /// </typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>
@@ -347,7 +347,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TClient">
         /// The type of the typed client. They type specified will be registered in the service collection as
-        /// a transient service. See <see cref="ITypedHttpClientFactory" /> for more details about authoring typed clients.
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
         /// </typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="configureClient">A delegate that is used to configure an <see cref="HttpClient"/>.</param>
@@ -391,11 +391,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TClient">
         /// The type of the typed client. They type specified will be registered in the service collection as
-        /// a transient service. See <see cref="ITypedHttpClientFactory" /> for more details about authoring typed clients.
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
         /// </typeparam>
         /// <typeparam name="TImplementation">
         /// The implementation type of the typed client. They type specified will be instantiated by the
-        /// <see cref="ITypedHttpClientFactory"/>
+        /// <see cref="ITypedHttpClientFactory{TImplementation}"/>
         /// </typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="configureClient">A delegate that is used to configure an <see cref="HttpClient"/>.</param>
@@ -442,7 +442,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TClient">
         /// The type of the typed client. They type specified will be registered in the service collection as
-        /// a transient service. See <see cref="ITypedHttpClientFactory" /> for more details about authoring typed clients.
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
         /// </typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>
@@ -494,11 +494,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TClient">
         /// The type of the typed client. They type specified will be registered in the service collection as
-        /// a transient service. See <see cref="ITypedHttpClientFactory" /> for more details about authoring typed clients.
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
         /// </typeparam>
         /// <typeparam name="TImplementation">
         /// The implementation type of the typed client. They type specified will be instantiated by the
-        /// <see cref="ITypedHttpClientFactory"/>
+        /// <see cref="ITypedHttpClientFactory{TImplementation}"/>
         /// </typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>

--- a/src/Microsoft.Extensions.Http/ITypedHttpClientFactory.cs
+++ b/src/Microsoft.Extensions.Http/ITypedHttpClientFactory.cs
@@ -11,21 +11,23 @@ namespace Microsoft.Extensions.Http
     /// A factory abstraction for a component that can create typed client instances with custom
     /// configuration for a given logical name.
     /// </summary>
+    /// <typeparam name="TClient">The type of typed client to create.</typeparam>
     /// <remarks>
     /// <para>
-    /// The <see cref="ITypedHttpClientFactory"/> is infrastructure that supports the
+    /// The <see cref="ITypedHttpClientFactory{TClient}"/> is infrastructure that supports the
     /// <see cref="HttpClientFactoryServiceCollectionExtensions.AddHttpClient{TClient}(IServiceCollection, string)"/> and
     /// <see cref="HttpClientBuilderExtensions.AddTypedClient{TClient}(IHttpClientBuilder)"/> functionality. This type
     /// should rarely be used directly in application code, use <see cref="IServiceProvider.GetService(Type)"/> instead
     /// to retrieve typed clients.
     /// </para>
     /// <para>
-    /// A default <see cref="ITypedHttpClientFactory"/> can be registered in an <see cref="IServiceCollection"/>
+    /// A default <see cref="ITypedHttpClientFactory{TClient}"/> can be registered in an <see cref="IServiceCollection"/>
     /// by calling <see cref="HttpClientFactoryServiceCollectionExtensions.AddHttpClient(IServiceCollection)"/>.
-    /// The default <see cref="ITypedHttpClientFactory"/> will be registered in the service collection as a singleton.
+    /// The default <see cref="ITypedHttpClientFactory{TClient}"/> will be registered in the service collection as a singleton
+    /// open-generic service.
     /// </para>
     /// <para>
-    /// The default <see cref="ITypedHttpClientFactory"/> uses type activation to create typed client instances. Typed
+    /// The default <see cref="ITypedHttpClientFactory{TClient}"/> uses type activation to create typed client instances. Typed
     /// client types are not retrieved directly from the <see cref="IServiceProvider"/>. See 
     /// <see cref="ActivatorUtilities.CreateInstance(IServiceProvider, Type, object[])" /> for details.
     /// </para>
@@ -94,17 +96,16 @@ namespace Microsoft.Extensions.Http
     /// }
     /// </code>
     /// </example>
-    public interface ITypedHttpClientFactory
+    public interface ITypedHttpClientFactory<TClient>
     {
         /// <summary>
         /// Creates a typed client given an associated <see cref="HttpClient"/>.
         /// </summary>
-        /// <typeparam name="TClient">The type of typed client to create.</typeparam>
         /// <param name="httpClient">
         /// An <see cref="HttpClient"/> created by the <see cref="IHttpClientFactory"/> for the named client
         /// associated with <typeparamref name="TClient"/>.
         /// </param>
         /// <returns>An instance of <typeparamref name="TClient"/>.</returns>
-        TClient CreateClient<TClient>(HttpClient httpClient);
+        TClient CreateClient(HttpClient httpClient);
     }
 }


### PR DESCRIPTION
This gives us a much better caching behavior for using
ActivatorUtilities and will avoid reflection on the common code path.