### PR TITLE
Adopt 6.0.0 builds of polly

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -19,8 +19,8 @@
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.7.49</MoqPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
-    <PollyExtensionsHttpSignedPackageVersion>1.0.4</PollyExtensionsHttpSignedPackageVersion>
-    <PollySignedPackageVersion>5.9.0</PollySignedPackageVersion>
+    <PollyExtensionsHttpPackageVersion>2.0.1</PollyExtensionsHttpPackageVersion>
+    <PollyPackageVersion>6.0.1</PollyPackageVersion>
     <XunitAnalyzersPackageVersion>0.8.0</XunitAnalyzersPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0-beta.1.build3945</XunitRunnerVisualStudioPackageVersion>

--- a/src/Microsoft.Extensions.Http.Polly/Microsoft.Extensions.Http.Polly.csproj
+++ b/src/Microsoft.Extensions.Http.Polly/Microsoft.Extensions.Http.Polly.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Polly-Signed" Version="$(PollySignedPackageVersion)" />
-    <PackageReference Include="Polly.Extensions.Http-Signed" Version="$(PollyExtensionsHttpSignedPackageVersion)" />
+    <PackageReference Include="Polly" Version="$(PollyPackageVersion)" />
+    <PackageReference Include="Polly.Extensions.Http" Version="$(PollyExtensionsHttpPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.ValueStopwatch.Sources" Version="$(MicrosoftExtensionsValueStopwatchSourcesPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
The polly packages have dropped the -Signed suffix because now they are
only offering the signed variant.

This is the version we will need to use in RTM