### PR TITLE
Add HttpMessageHandler factory

### DIFF
--- a/src/Microsoft.Extensions.Http/DefaultHttpClientFactory.cs
+++ b/src/Microsoft.Extensions.Http/DefaultHttpClientFactory.cs
@@ -117,15 +117,9 @@ namespace Microsoft.Extensions.Http
 
         public HttpClient CreateClient(string name)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            HttpMessageHandler handler = CreateHandler(name);
 
-            var entry = _activeHandlers.GetOrAdd(name, _entryFactory).Value;
-            var client = new HttpClient(entry.Handler, disposeHandler: false);
-
-            StartHandlerEntryTimer(entry);
+            var client = new HttpClient(handler, disposeHandler: false);
 
             var options = _optionsMonitor.Get(name);
             for (var i = 0; i < options.HttpClientActions.Count; i++)

--- a/src/Microsoft.Extensions.Http/DefaultHttpClientFactory.cs
+++ b/src/Microsoft.Extensions.Http/DefaultHttpClientFactory.cs
@@ -138,11 +138,10 @@ namespace Microsoft.Extensions.Http
             }
 
             var entry = _activeHandlers.GetOrAdd(name, _entryFactory).Value;
-            var handler = new LifetimeTrackingHttpMessageHandlerWrapper(entry.Handler);
 
             StartHandlerEntryTimer(entry);
 
-            return handler;
+            return entry.Handler;
         }
 
         // Internal for tests
@@ -377,21 +376,6 @@ namespace Microsoft.Extensions.Http
             public static void HandlerExpired(ILogger logger, string clientName, TimeSpan lifetime)
             {
                 _handlerExpired(logger, lifetime.TotalMilliseconds, clientName, null);
-            }
-        }
-
-        // Wraps the inner handler in the same manner as HttpClient so that the caller can
-        // dispose of the handler freely without affecting it being shared with other clients
-        private sealed class LifetimeTrackingHttpMessageHandlerWrapper : DelegatingHandler
-        {
-            internal LifetimeTrackingHttpMessageHandlerWrapper(LifetimeTrackingHttpMessageHandler handler)
-                : base(handler)
-            {
-            }
-
-            protected override void Dispose(bool disposing)
-            {
-                // The lifetime of the LifetimeTrackingHttpMessageHandler is tracked separately
             }
         }
     }

--- a/src/Microsoft.Extensions.Http/DefaultHttpClientFactory.cs
+++ b/src/Microsoft.Extensions.Http/DefaultHttpClientFactory.cs
@@ -117,8 +117,12 @@ namespace Microsoft.Extensions.Http
 
         public HttpClient CreateClient(string name)
         {
-            HttpMessageHandler handler = CreateHandler(name);
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
 
+            var handler = CreateHandler(name);
             var client = new HttpClient(handler, disposeHandler: false);
 
             var options = _optionsMonitor.Get(name);

--- a/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -33,7 +33,9 @@ namespace Microsoft.Extensions.DependencyInjection
             // Core abstractions
             //
             services.TryAddTransient<HttpMessageHandlerBuilder, DefaultHttpMessageHandlerBuilder>();
-            services.TryAddSingleton<IHttpClientFactory, DefaultHttpClientFactory>();
+            services.AddSingleton<DefaultHttpClientFactory>();
+            services.TryAddSingleton<IHttpClientFactory>(serviceProvider => serviceProvider.GetRequiredService<DefaultHttpClientFactory>());
+            services.TryAddSingleton<IHttpMessageHandlerFactory>(serviceProvider => serviceProvider.GetRequiredService<DefaultHttpClientFactory>());
 
             //
             // Typed Clients

--- a/src/Microsoft.Extensions.Http/HttpMessageHandlerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Http/HttpMessageHandlerFactoryExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Options;
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// Extensions methods for <see cref="IHttpMessageHandlerFactory"/>.
+    /// </summary>
+    public static class HttpMessageHandlerFactoryExtensions
+    {
+        /// <summary>
+        /// Creates a new <see cref="HttpMessageHandler"/> using the default configuration.
+        /// </summary>
+        /// <param name="factory">The <see cref="IHttpMessageHandlerFactory"/>.</param>
+        /// <returns>An <see cref="HttpMessageHandler"/> configured using the default configuration.</returns>
+        public static HttpMessageHandler CreateHandler(this IHttpMessageHandlerFactory factory)
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            return factory.CreateHandler(Options.DefaultName);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Http/IHttpMessageHandlerFactory.cs
+++ b/src/Microsoft.Extensions.Http/IHttpMessageHandlerFactory.cs
@@ -24,13 +24,13 @@ namespace System.Net.Http
         /// <returns>A new <see cref="HttpMessageHandler"/> instance.</returns>
         /// <remarks>
         /// <para>
-        /// Each call to <see cref="CreateHandler(string)"/> is guaranteed to return a new <see cref="HttpMessageHandler"/>
-        /// instance. Callers may cache the returned <see cref="HttpMessageHandler"/> instance indefinitely or surround
-        /// its use in a <langword>using</langword> block to dispose it when desired.
-        /// </para>
-        /// <para>
         /// The default <see cref="IHttpMessageHandlerFactory"/> implementation may cache the underlying
         /// <see cref="HttpMessageHandler"/> instances to improve performance.
+        /// </para>
+        /// <para>
+        /// The default <see cref="IHttpMessageHandlerFactory"/> implementation also manages the lifetime of the
+        /// handler created, so disposing of the <see cref="HttpMessageHandler"/> returned by this method may
+        /// have no effect.
         /// </para>
         /// </remarks>
         HttpMessageHandler CreateHandler(string name);

--- a/src/Microsoft.Extensions.Http/IHttpMessageHandlerFactory.cs
+++ b/src/Microsoft.Extensions.Http/IHttpMessageHandlerFactory.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// A factory abstraction for a component that can create <see cref="HttpMessageHandler"/> instances with custom
+    /// configuration for a given logical name.
+    /// </summary>
+    /// <remarks>
+    /// A default <see cref="IHttpMessageHandlerFactory"/> can be registered in an <see cref="IServiceCollection"/>
+    /// by calling <see cref="HttpClientFactoryServiceCollectionExtensions.AddHttpClient(IServiceCollection)"/>.
+    /// The default <see cref="IHttpMessageHandlerFactory"/> will be registered in the service collection as a singleton.
+    /// </remarks>
+    public interface IHttpMessageHandlerFactory
+    {
+        /// <summary>
+        /// Creates and configures an <see cref="HttpMessageHandler"/> instance using the configuration that corresponds
+        /// to the logical name specified by <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The logical name of the message handler to create.</param>
+        /// <returns>A new <see cref="HttpMessageHandler"/> instance.</returns>
+        /// <remarks>
+        /// <para>
+        /// Each call to <see cref="CreateHandler(string)"/> is guaranteed to return a new <see cref="HttpMessageHandler"/>
+        /// instance. Callers may cache the returned <see cref="HttpMessageHandler"/> instance indefinitely or surround
+        /// its use in a <langword>using</langword> block to dispose it when desired.
+        /// </para>
+        /// <para>
+        /// The default <see cref="IHttpMessageHandlerFactory"/> implementation may cache the underlying
+        /// <see cref="HttpMessageHandler"/> instances to improve performance.
+        /// </para>
+        /// </remarks>
+        HttpMessageHandler CreateHandler(string name);
+    }
+}

--- a/src/Microsoft.Extensions.Http/LifetimeTrackingHttpMessageHandler.cs
+++ b/src/Microsoft.Extensions.Http/LifetimeTrackingHttpMessageHandler.cs
@@ -14,5 +14,10 @@ namespace Microsoft.Extensions.Http
             : base(innerHandler)
         {
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            // The lifetime of this is tracked separately by ActiveHandlerTrackingEntry
+        }
     }
 }

--- a/test/Microsoft.Extensions.Http.Test/DefaultHttpClientFactoryTest.cs
+++ b/test/Microsoft.Extensions.Http.Test/DefaultHttpClientFactoryTest.cs
@@ -107,6 +107,31 @@ namespace Microsoft.Extensions.Http
         }
 
         [Fact]
+        public void Factory_DisposeHandler_DoesNotDisposeInnerHandler()
+        {
+            // Arrange
+            Options.CurrentValue.HttpMessageHandlerBuilderActions.Add(b =>
+            {
+                var mockHandler = new Mock<HttpMessageHandler>();
+                mockHandler
+                    .Protected()
+                    .Setup("Dispose", true)
+                    .Throws(new Exception("Dispose should not be called"));
+
+                b.PrimaryHandler = mockHandler.Object;
+            });
+
+            var factory = new TestHttpClientFactory(Services, ScopeFactory, LoggerFactory, Options, EmptyFilters);
+
+            // Act 
+            using (factory.CreateHandler())
+            {
+            }
+
+            // Assert (does not throw)
+        }
+
+        [Fact]
         public void Factory_CreateClient_WithoutName_UsesDefaultOptions()
         {
             // Arrange


### PR DESCRIPTION
Add a simple abstraction to allow leveraging the configurability of `IHttpClientFactory` for creating `HttpMessageHandler` instances that use the same configured message handler chains as are available for `HttpClient` instances.

I've just piggybacked the `DefaultHttpClientFactory` class to provide the implementation, with an extension method and a private class to wrap the message handler so it's "dispose-proof" like the handlers used in the `HttpClient` instances are.

The primary use-case is for interop with existing .NET libraries that use `HttpMessageHandler` as their HTTP abstraction rather than `HttpClient`, so that features like logging and resilience can be lit-up for these scenarios.

Relates to #110.
