### PR TITLE
New extension methods for typed HTTP clients

### DIFF
--- a/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -393,6 +393,50 @@ namespace Microsoft.Extensions.DependencyInjection
         /// The type of the typed client. They type specified will be registered in the service collection as
         /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
         /// </typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configureClient">A delegate that is used to configure an <see cref="HttpClient"/>.</param>
+        /// <returns>An <see cref="IHttpClientBuilder"/> that can be used to configure the client.</returns>
+        /// <remarks>
+        /// <para>
+        /// <see cref="HttpClient"/> instances that apply the provided configuration can be retrieved using 
+        /// <see cref="IHttpClientFactory.CreateClient(string)"/> and providing the matching name.
+        /// </para>
+        /// <para>
+        /// <typeparamref name="TClient"/> instances constructed with the appropriate <see cref="HttpClient" />
+        /// can be retrieved from <see cref="IServiceProvider.GetService(Type)" /> (and related methods) by providing
+        /// <typeparamref name="TClient"/> as the service type. 
+        /// </para>
+        /// </remarks>
+        public static IHttpClientBuilder AddHttpClient<TClient>(this IServiceCollection services, Action<IServiceProvider, HttpClient> configureClient)
+            where TClient : class
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configureClient == null)
+            {
+                throw new ArgumentNullException(nameof(configureClient));
+            }
+
+            AddHttpClient(services);
+
+            var builder = new DefaultHttpClientBuilder(services, typeof(TClient).Name);
+            builder.ConfigureHttpClient(configureClient);
+            builder.AddTypedClient<TClient>();
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds the <see cref="IHttpClientFactory"/> and related services to the <see cref="IServiceCollection"/> and configures
+        /// a binding between the <typeparamref name="TClient" /> type and a named <see cref="HttpClient"/>. The client name will
+        /// be set to the type name of <typeparamref name="TClient"/>.
+        /// </summary>
+        /// <typeparam name="TClient">
+        /// The type of the typed client. They type specified will be registered in the service collection as
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
+        /// </typeparam>
         /// <typeparam name="TImplementation">
         /// The implementation type of the typed client. They type specified will be instantiated by the
         /// <see cref="ITypedHttpClientFactory{TImplementation}"/>
@@ -415,6 +459,58 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </para>
         /// </remarks>
         public static IHttpClientBuilder AddHttpClient<TClient, TImplementation>(this IServiceCollection services, Action<HttpClient> configureClient)
+            where TClient : class
+            where TImplementation : class, TClient
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configureClient == null)
+            {
+                throw new ArgumentNullException(nameof(configureClient));
+            }
+
+            AddHttpClient(services);
+
+            var builder = new DefaultHttpClientBuilder(services, typeof(TClient).Name);
+            builder.ConfigureHttpClient(configureClient);
+            builder.AddTypedClient<TClient, TImplementation>();
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds the <see cref="IHttpClientFactory"/> and related services to the <see cref="IServiceCollection"/> and configures
+        /// a binding between the <typeparamref name="TClient" /> type and a named <see cref="HttpClient"/>. The client name will
+        /// be set to the type name of <typeparamref name="TClient"/>.
+        /// </summary>
+        /// <typeparam name="TClient">
+        /// The type of the typed client. They type specified will be registered in the service collection as
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
+        /// </typeparam>
+        /// <typeparam name="TImplementation">
+        /// The implementation type of the typed client. They type specified will be instantiated by the
+        /// <see cref="ITypedHttpClientFactory{TImplementation}"/>
+        /// </typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configureClient">A delegate that is used to configure an <see cref="HttpClient"/>.</param>
+        /// <returns>An <see cref="IHttpClientBuilder"/> that can be used to configure the client.</returns>
+        /// <remarks>
+        /// <para>
+        /// <see cref="HttpClient"/> instances that apply the provided configuration can be retrieved using 
+        /// <see cref="IHttpClientFactory.CreateClient(string)"/> and providing the matching name.
+        /// </para>
+        /// <para>
+        /// <typeparamref name="TClient"/> instances constructed with the appropriate <see cref="HttpClient" />
+        /// can be retrieved from <see cref="IServiceProvider.GetService(Type)" /> (and related methods) by providing
+        /// <typeparamref name="TClient"/> as the service type. 
+        /// </para>
+        /// <para>
+        /// Use <see cref="Options.Options.DefaultName"/> as the name to configure the default client.
+        /// </para>
+        /// </remarks>
+        public static IHttpClientBuilder AddHttpClient<TClient, TImplementation>(this IServiceCollection services, Action<IServiceProvider, HttpClient> configureClient)
             where TClient : class
             where TImplementation : class, TClient
         {
@@ -496,6 +592,58 @@ namespace Microsoft.Extensions.DependencyInjection
         /// The type of the typed client. They type specified will be registered in the service collection as
         /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
         /// </typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>
+        /// <param name="configureClient">A delegate that is used to configure an <see cref="HttpClient"/>.</param>
+        /// <returns>An <see cref="IHttpClientBuilder"/> that can be used to configure the client.</returns>
+        /// <remarks>
+        /// <para>
+        /// <see cref="HttpClient"/> instances that apply the provided configuration can be retrieved using 
+        /// <see cref="IHttpClientFactory.CreateClient(string)"/> and providing the matching name.
+        /// </para>
+        /// <para>
+        /// <typeparamref name="TClient"/> instances constructed with the appropriate <see cref="HttpClient" />
+        /// can be retrieved from <see cref="IServiceProvider.GetService(Type)" /> (and related methods) by providing
+        /// <typeparamref name="TClient"/> as the service type. 
+        /// </para>
+        /// <para>
+        /// Use <see cref="Options.Options.DefaultName"/> as the name to configure the default client.
+        /// </para>
+        /// </remarks>
+        public static IHttpClientBuilder AddHttpClient<TClient>(this IServiceCollection services, string name, Action<IServiceProvider, HttpClient> configureClient)
+            where TClient : class
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (configureClient == null)
+            {
+                throw new ArgumentNullException(nameof(configureClient));
+            }
+
+            AddHttpClient(services);
+
+            var builder = new DefaultHttpClientBuilder(services, name);
+            builder.ConfigureHttpClient(configureClient);
+            builder.AddTypedClient<TClient>();
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds the <see cref="IHttpClientFactory"/> and related services to the <see cref="IServiceCollection"/> and configures
+        /// a binding between the <typeparamref name="TClient" /> type and a named <see cref="HttpClient"/>.
+        /// </summary>
+        /// <typeparam name="TClient">
+        /// The type of the typed client. They type specified will be registered in the service collection as
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
+        /// </typeparam>
         /// <typeparam name="TImplementation">
         /// The implementation type of the typed client. They type specified will be instantiated by the
         /// <see cref="ITypedHttpClientFactory{TImplementation}"/>
@@ -519,6 +667,63 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </para>
         /// </remarks>
         public static IHttpClientBuilder AddHttpClient<TClient, TImplementation>(this IServiceCollection services, string name, Action<HttpClient> configureClient)
+            where TClient : class
+            where TImplementation : class, TClient
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (configureClient == null)
+            {
+                throw new ArgumentNullException(nameof(configureClient));
+            }
+
+            AddHttpClient(services);
+
+            var builder = new DefaultHttpClientBuilder(services, name);
+            builder.ConfigureHttpClient(configureClient);
+            builder.AddTypedClient<TClient, TImplementation>();
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds the <see cref="IHttpClientFactory"/> and related services to the <see cref="IServiceCollection"/> and configures
+        /// a binding between the <typeparamref name="TClient" /> type and a named <see cref="HttpClient"/>.
+        /// </summary>
+        /// <typeparam name="TClient">
+        /// The type of the typed client. They type specified will be registered in the service collection as
+        /// a transient service. See <see cref="ITypedHttpClientFactory{TClient}" /> for more details about authoring typed clients.
+        /// </typeparam>
+        /// <typeparam name="TImplementation">
+        /// The implementation type of the typed client. They type specified will be instantiated by the
+        /// <see cref="ITypedHttpClientFactory{TImplementation}"/>
+        /// </typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>
+        /// <param name="configureClient">A delegate that is used to configure an <see cref="HttpClient"/>.</param>
+        /// <returns>An <see cref="IHttpClientBuilder"/> that can be used to configure the client.</returns>
+        /// <remarks>
+        /// <para>
+        /// <see cref="HttpClient"/> instances that apply the provided configuration can be retrieved using 
+        /// <see cref="IHttpClientFactory.CreateClient(string)"/> and providing the matching name.
+        /// </para>
+        /// <para>
+        /// <typeparamref name="TClient"/> instances constructed with the appropriate <see cref="HttpClient" />
+        /// can be retrieved from <see cref="IServiceProvider.GetService(Type)" /> (and related methods) by providing
+        /// <typeparamref name="TClient"/> as the service type. 
+        /// </para>
+        /// <para>
+        /// Use <see cref="Options.Options.DefaultName"/> as the name to configure the default client.
+        /// </para>
+        /// </remarks>
+        public static IHttpClientBuilder AddHttpClient<TClient, TImplementation>(this IServiceCollection services, string name, Action<IServiceProvider, HttpClient> configureClient)
             where TClient : class
             where TImplementation : class, TClient
         {

--- a/test/Microsoft.Extensions.Http.Test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Http.Test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -354,6 +354,7 @@ namespace Microsoft.Extensions.DependencyInjection
         [Fact]
         public void AddHttpMessageHandler_WithName_NewHandlerIsSurroundedByLogging()
         {
+            // Arrange
             var serviceCollection = new ServiceCollection();
 
             HttpMessageHandlerBuilder builder = null;
@@ -382,6 +383,114 @@ namespace Microsoft.Extensions.DependencyInjection
                 h => Assert.IsType<LoggingScopeHttpMessageHandler>(h),
                 h => Assert.NotNull(h),
                 h => Assert.IsType<LoggingHttpMessageHandler>(h));
+        }
+
+        [Fact]
+        public void AddHttpClient_WithTypedClient_AndServiceDelegate_ConfiguresClient()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.Configure<OtherTestOptions>(options =>
+            {
+                options.BaseAddress = "http://example.com/";
+            });
+
+            // Act1
+            serviceCollection.AddHttpClient<TestTypedClient>((s,c) =>
+            {
+                var options = s.GetRequiredService<IOptions<OtherTestOptions>>();
+                c.BaseAddress = new Uri(options.Value.BaseAddress);
+            });
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            // Act2
+            var client = services.GetRequiredService<TestTypedClient>();
+        
+            // Assert
+            Assert.Equal("http://example.com/", client.HttpClient.BaseAddress.AbsoluteUri);
+        }
+
+        [Fact]
+        public void AddHttpClient_WithTypedClientAndImplementation_AndServiceDelegate_ConfiguresClient()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.Configure<OtherTestOptions>(options =>
+            {
+                options.BaseAddress = "http://example.com/";
+            });
+
+            // Act1
+            serviceCollection.AddHttpClient<ITestTypedClient, TestTypedClient>((s,c) =>
+            {
+                var options = s.GetRequiredService<IOptions<OtherTestOptions>>();
+                c.BaseAddress = new Uri(options.Value.BaseAddress);
+            });
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            // Act2
+            var client = services.GetRequiredService<ITestTypedClient>();
+        
+            // Assert
+            Assert.Equal("http://example.com/", client.HttpClient.BaseAddress.AbsoluteUri);
+        }
+
+        [Fact]
+        public void AddHttpClient_WithTypedClient_AndServiceDelegate_ConfiguresNamedClient()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.Configure<OtherTestOptions>(options =>
+            {
+                options.BaseAddress = "http://example.com/";
+            });
+
+            // Act1
+            serviceCollection.AddHttpClient<TestTypedClient>("test", (s,c) =>
+            {
+                var options = s.GetRequiredService<IOptions<OtherTestOptions>>();
+                c.BaseAddress = new Uri(options.Value.BaseAddress);
+            });
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            // Act2
+            var client = services.GetRequiredService<TestTypedClient>();
+        
+            // Assert
+            Assert.Equal("http://example.com/", client.HttpClient.BaseAddress.AbsoluteUri);
+        }
+
+        [Fact]
+        public void AddHttpClient_WithTypedClientAndImplementation_AndServiceDelegate_ConfiguresNamedClient()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.Configure<OtherTestOptions>(options =>
+            {
+                options.BaseAddress = "http://example.com/";
+            });
+
+            // Act1
+            serviceCollection.AddHttpClient<ITestTypedClient, TestTypedClient>("test", (s,c) =>
+            {
+                var options = s.GetRequiredService<IOptions<OtherTestOptions>>();
+                c.BaseAddress = new Uri(options.Value.BaseAddress);
+            });
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            // Act2
+            var client = services.GetRequiredService<ITestTypedClient>();
+        
+            // Assert
+            Assert.Equal("http://example.com/", client.HttpClient.BaseAddress.AbsoluteUri);
         }
     }
 }

--- a/test/Microsoft.Extensions.Http.Test/DependencyInjection/OtherTestOptions.cs
+++ b/test/Microsoft.Extensions.Http.Test/DependencyInjection/OtherTestOptions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public class OtherTestOptions
+    {
+        public string BaseAddress { get; set; }
+    }
+}


### PR DESCRIPTION
- Add new extension methods with `IServiceProvider` to configure typed HTTP clients
- Add tests for experience with configuration 

Addresses #116 @rynowak 