### PR TITLE
Fix #151 - allow multiple generic typed clients

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -13,6 +13,7 @@
     <MicrosoftExtensionsLoggingConsolePackageVersion>2.2.0-preview1-34967</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>2.2.0-preview1-34967</MicrosoftExtensionsLoggingPackageVersion>
     <MicrosoftExtensionsOptionsPackageVersion>2.2.0-preview1-34967</MicrosoftExtensionsOptionsPackageVersion>
+    <MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>2.2.0-preview1-34967</MicrosoftExtensionsTypeNameHelperSourcesPackageVersion>
     <MicrosoftExtensionsValueStopwatchSourcesPackageVersion>2.2.0-preview1-34967</MicrosoftExtensionsValueStopwatchSourcesPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.2</MicrosoftNETCoreApp21PackageVersion>

--- a/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -183,9 +184,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// can be retrieved from <see cref="IServiceProvider.GetService(Type)" /> (and related methods) by providing
         /// <typeparamref name="TClient"/> as the service type. 
         /// </para>
-        /// <para>
-        /// Use <see cref="Options.Options.DefaultName"/> as the name to configure the default client.
-        /// </para>
         /// </remarks>
         public static IHttpClientBuilder AddHttpClient<TClient>(this IServiceCollection services)
             where TClient : class
@@ -197,7 +195,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             AddHttpClient(services);
 
-            var builder = new DefaultHttpClientBuilder(services, typeof(TClient).Name);
+            var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            var builder = new DefaultHttpClientBuilder(services, name);
             builder.AddTypedClient<TClient>();
             return builder;
         }
@@ -239,7 +238,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             AddHttpClient(services);
 
-            var builder = new DefaultHttpClientBuilder(services, typeof(TClient).Name);
+            var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            var builder = new DefaultHttpClientBuilder(services, name);
             builder.AddTypedClient<TClient, TImplementation>();
             return builder;
         }
@@ -378,7 +378,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             AddHttpClient(services);
 
-            var builder = new DefaultHttpClientBuilder(services, typeof(TClient).Name);
+            var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
             builder.AddTypedClient<TClient>();
             return builder;
@@ -422,7 +423,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             AddHttpClient(services);
 
-            var builder = new DefaultHttpClientBuilder(services, typeof(TClient).Name);
+            var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
             builder.AddTypedClient<TClient>();
             return builder;
@@ -454,9 +456,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// can be retrieved from <see cref="IServiceProvider.GetService(Type)" /> (and related methods) by providing
         /// <typeparamref name="TClient"/> as the service type. 
         /// </para>
-        /// <para>
-        /// Use <see cref="Options.Options.DefaultName"/> as the name to configure the default client.
-        /// </para>
         /// </remarks>
         public static IHttpClientBuilder AddHttpClient<TClient, TImplementation>(this IServiceCollection services, Action<HttpClient> configureClient)
             where TClient : class
@@ -474,7 +473,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             AddHttpClient(services);
 
-            var builder = new DefaultHttpClientBuilder(services, typeof(TClient).Name);
+            var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
             builder.AddTypedClient<TClient, TImplementation>();
             return builder;
@@ -506,9 +506,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// can be retrieved from <see cref="IServiceProvider.GetService(Type)" /> (and related methods) by providing
         /// <typeparamref name="TClient"/> as the service type. 
         /// </para>
-        /// <para>
-        /// Use <see cref="Options.Options.DefaultName"/> as the name to configure the default client.
-        /// </para>
         /// </remarks>
         public static IHttpClientBuilder AddHttpClient<TClient, TImplementation>(this IServiceCollection services, Action<IServiceProvider, HttpClient> configureClient)
             where TClient : class
@@ -526,7 +523,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             AddHttpClient(services);
 
-            var builder = new DefaultHttpClientBuilder(services, typeof(TClient).Name);
+            var name = TypeNameHelper.GetTypeDisplayName(typeof(TClient), fullName: false);
+            var builder = new DefaultHttpClientBuilder(services, name);
             builder.ConfigureHttpClient(configureClient);
             builder.AddTypedClient<TClient, TImplementation>();
             return builder;

--- a/src/Microsoft.Extensions.Http/Microsoft.Extensions.Http.csproj
+++ b/src/Microsoft.Extensions.Http/Microsoft.Extensions.Http.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.TypeNameHelper.Sources" Version="$(MicrosoftExtensionsTypeNameHelperSourcesPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.ValueStopwatch.Sources" Version="$(MicrosoftExtensionsValueStopwatchSourcesPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/test/Microsoft.Extensions.Http.Test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Http.Test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -100,6 +100,29 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
+        public void AddHttpClient_WithGenericTypedClient_ConfiguresNamedClient()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.Configure<HttpClientFactoryOptions>("TestGenericTypedClient<string>", options =>
+            {
+                options.HttpClientActions.Add((c) => c.BaseAddress = new Uri("http://example.com"));
+            });
+
+            // Act
+            serviceCollection.AddHttpClient<TestGenericTypedClient<string>>();
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            // Act2
+            var client = services.GetRequiredService<TestGenericTypedClient<string>>();
+
+            // Assert
+            Assert.Equal("http://example.com/", client.HttpClient.BaseAddress.AbsoluteUri);
+        }
+
+        [Fact]
         public void AddHttpClient_WithTypedClientAndImplementation_ConfiguresNamedClient()
         {
             // Arrange
@@ -491,6 +514,14 @@ namespace Microsoft.Extensions.DependencyInjection
         
             // Assert
             Assert.Equal("http://example.com/", client.HttpClient.BaseAddress.AbsoluteUri);
+        }
+
+        private class TestGenericTypedClient<T> : TestTypedClient
+        {
+            public TestGenericTypedClient(HttpClient httpClient)
+                : base(httpClient)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
Addresses a usability issue where typed clients with generic type
parameters didn't work well. This is broken because Type.Name always
uses the metadata name 'MyClientType`1' instead of the name that the
user typed in code.

This change uses some existing infrastructure we have to 'pretty print'
the type name.

The subtle breaking change here is that if you were using
`services.Configure(typeof(MyClient<>).Name, ...)` this will no longer
work. Doing these operations through the builder we provide will work
just fine, so I'm not terribly concerned.