### PR TITLE
Fix #124 and #134

### DIFF
--- a/src/Microsoft.Extensions.Http/ActiveHandlerTrackingEntry.cs
+++ b/src/Microsoft.Extensions.Http/ActiveHandlerTrackingEntry.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Http
 {
@@ -16,10 +17,15 @@ namespace Microsoft.Extensions.Http
         private Timer _timer;
         private TimerCallback _callback;
 
-        public ActiveHandlerTrackingEntry(string name, LifetimeTrackingHttpMessageHandler handler, TimeSpan lifetime)
+        public ActiveHandlerTrackingEntry(
+            string name,
+            LifetimeTrackingHttpMessageHandler handler,
+            IServiceScope scope,
+            TimeSpan lifetime)
         {
             Name = name;
             Handler = handler;
+            Scope = scope;
             Lifetime = lifetime;
 
             _lock = new object();
@@ -30,6 +36,8 @@ namespace Microsoft.Extensions.Http
         public TimeSpan Lifetime { get; }
 
         public string Name { get; }
+
+        public IServiceScope Scope { get; }
 
         public void StartExpiryTimer(TimerCallback callback)
         {

--- a/src/Microsoft.Extensions.Http/DefaultHttpMessageHandlerBuilder.cs
+++ b/src/Microsoft.Extensions.Http/DefaultHttpMessageHandlerBuilder.cs
@@ -9,6 +9,11 @@ namespace Microsoft.Extensions.Http
 {
     internal class DefaultHttpMessageHandlerBuilder : HttpMessageHandlerBuilder
     {
+        public DefaultHttpMessageHandlerBuilder(IServiceProvider services)
+        {
+            Services = services;
+        }
+
         private string _name;
 
         public override string Name
@@ -28,6 +33,8 @@ namespace Microsoft.Extensions.Http
         public override HttpMessageHandler PrimaryHandler { get; set; } = new HttpClientHandler();
 
         public override IList<DelegatingHandler> AdditionalHandlers { get; } = new List<DelegatingHandler>();
+
+        public override IServiceProvider Services { get; }
 
         public override HttpMessageHandler Build()
         {

--- a/src/Microsoft.Extensions.Http/DefaultTypedHttpClientFactory.cs
+++ b/src/Microsoft.Extensions.Http/DefaultTypedHttpClientFactory.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Extensions.Http
     internal class DefaultTypedHttpClientFactory<TClient> : ITypedHttpClientFactory<TClient>
     {
         private readonly static Func<ObjectFactory> _createActivator = () => ActivatorUtilities.CreateFactory(typeof(TClient), new Type[] { typeof(HttpClient), });
-        private readonly IServiceProvider _services;
+        private static ObjectFactory _activator;
+        private static bool _initialized;
+        private static object _lock;
 
-        private ObjectFactory _activator;
-        private bool _initialized;
-        private object _lock;
+        private readonly IServiceProvider _services;
 
         public DefaultTypedHttpClientFactory(IServiceProvider services)
         {

--- a/src/Microsoft.Extensions.Http/DefaultTypedHttpClientFactory.cs
+++ b/src/Microsoft.Extensions.Http/DefaultTypedHttpClientFactory.cs
@@ -10,20 +10,22 @@ namespace Microsoft.Extensions.Http
 {
     internal class DefaultTypedHttpClientFactory<TClient> : ITypedHttpClientFactory<TClient>
     {
-        private readonly static Func<ObjectFactory> _createActivator = () => ActivatorUtilities.CreateFactory(typeof(TClient), new Type[] { typeof(HttpClient), });
-        private static ObjectFactory _activator;
-        private static bool _initialized;
-        private static object _lock;
-
+        private readonly Cache _cache;
         private readonly IServiceProvider _services;
 
-        public DefaultTypedHttpClientFactory(IServiceProvider services)
+        public DefaultTypedHttpClientFactory(Cache cache, IServiceProvider services)
         {
+            if (cache == null)
+            {
+                throw new ArgumentNullException(nameof(cache));
+            }
+
             if (services == null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
+            _cache = cache;
             _services = services;
         }
 
@@ -34,8 +36,37 @@ namespace Microsoft.Extensions.Http
                 throw new ArgumentNullException(nameof(httpClient));
             }
 
-            LazyInitializer.EnsureInitialized(ref _activator, ref _initialized, ref _lock, _createActivator);
-            return (TClient)_activator(_services, new object[] { httpClient });
+            return (TClient)_cache.Activator(_services, new object[] { httpClient });
+        }
+
+        // The Cache should be registed as a singleton, so it that it can
+        // act as a cache for the Activator. This allows the outer class to be registered
+        // as a transient, so that it doesn't close over the application root service provider.
+        public class Cache
+        {
+            private readonly static Func<ObjectFactory> _createActivator = () => ActivatorUtilities.CreateFactory(typeof(TClient), new Type[] { typeof(HttpClient), });
+
+            private readonly IServiceProvider _services;
+
+            private ObjectFactory _activator;
+            private bool _initialized;
+            private object _lock;
+
+            public Cache(IServiceProvider services)
+            {
+                if (services == null)
+                {
+                    throw new ArgumentNullException(nameof(services));
+                }
+
+                _services = services;
+            }
+
+            public ObjectFactory Activator => LazyInitializer.EnsureInitialized(
+                ref _activator, 
+                ref _initialized, 
+                ref _lock, 
+                _createActivator);
         }
     }
 }

--- a/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientBuilderExtensions.cs
@@ -43,6 +43,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">The <see cref="IServiceCollection"/>.</param>
         /// <param name="configureClient">A delegate that is used to configure an <see cref="HttpClient"/>.</param>
         /// <returns>An <see cref="IHttpClientBuilder"/> that can be used to configure the client.</returns>
+        /// <remarks>
+        /// The <see cref="IServiceProvider"/> provided to <paramref name="configureClient"/> will be the
+        /// same application's root service provider instance.
+        /// </remarks>
         public static IHttpClientBuilder ConfigureHttpClient(this IHttpClientBuilder builder, Action<IServiceProvider, HttpClient> configureClient)
         {
             if (builder == null)
@@ -102,8 +106,14 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">The <see cref="IHttpClientBuilder"/>.</param>
         /// <param name="configureHandler">A delegate that is used to create a <see cref="DelegatingHandler"/>.</param>       /// <returns>An <see cref="IHttpClientBuilder"/> that can be used to configure the client.</returns>
         /// <remarks>
+        /// <para>
         /// The <see paramref="configureHandler"/> delegate should return a new instance of the message handler each time it
         /// is invoked.
+        /// </para>
+        /// <para>
+        /// The <see cref="IServiceProvider"/> argument provided to <paramref name="configureHandler"/> will be
+        /// a reference to a scoped service provider that shares the lifetime of the handler being constructed.
+        /// </para>
         /// </remarks>
         public static IHttpClientBuilder AddHttpMessageHandler(this IHttpClientBuilder builder, Func<IServiceProvider, DelegatingHandler> configureHandler)
         {
@@ -117,12 +127,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(configureHandler));
             }
 
-            builder.Services.AddTransient<IConfigureOptions<HttpClientFactoryOptions>>(services =>
+            builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                return new ConfigureNamedOptions<HttpClientFactoryOptions>(builder.Name, (options) =>
-                {
-                    options.HttpMessageHandlerBuilderActions.Add(b => b.AdditionalHandlers.Add(configureHandler(services)));
-                });
+                options.HttpMessageHandlerBuilderActions.Add(b => b.AdditionalHandlers.Add(configureHandler(b.Services)));
             });
 
             return builder;
@@ -136,6 +143,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="THandler">
         /// The type of the <see cref="DelegatingHandler"/>. The handler type must be registered as a transient service.
         /// </typeparam>
+        /// <remarks>
+        /// <para>
+        /// The <typeparamref name="THandler"/> will be resolved from a scoped service provider that shares 
+        /// the lifetime of the handler being constructed.
+        /// </para>
+        /// </remarks>
         public static IHttpClientBuilder AddHttpMessageHandler<THandler>(this IHttpClientBuilder builder)
             where THandler : DelegatingHandler
         {
@@ -144,12 +157,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.Services.AddTransient<IConfigureOptions<HttpClientFactoryOptions>>(services =>
+            builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                return new ConfigureNamedOptions<HttpClientFactoryOptions>(builder.Name, (options) =>
-                {
-                    options.HttpMessageHandlerBuilderActions.Add(b => b.AdditionalHandlers.Add(services.GetRequiredService<THandler>()));
-                });
+                options.HttpMessageHandlerBuilderActions.Add(b => b.AdditionalHandlers.Add(b.Services.GetRequiredService<THandler>()));
             });
 
             return builder;
@@ -194,8 +204,14 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configureHandler">A delegate that is used to create an <see cref="HttpMessageHandler"/>.</param>
         /// <returns>An <see cref="IHttpClientBuilder"/> that can be used to configure the client.</returns>
         /// <remarks>
+        /// <para>
         /// The <see paramref="configureHandler"/> delegate should return a new instance of the message handler each time it
         /// is invoked.
+        /// </para>
+        /// <para>
+        /// The <see cref="IServiceProvider"/> argument provided to <paramref name="configureHandler"/> will be
+        /// a reference to a scoped service provider that shares the lifetime of the handler being constructed.
+        /// </para>
         /// </remarks>
         public static IHttpClientBuilder ConfigurePrimaryHttpMessageHandler(this IHttpClientBuilder builder, Func<IServiceProvider, HttpMessageHandler> configureHandler)
         {
@@ -209,12 +225,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(configureHandler));
             }
 
-            builder.Services.AddTransient<IConfigureOptions<HttpClientFactoryOptions>>(services =>
+            builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
             {
-                return new ConfigureNamedOptions<HttpClientFactoryOptions>(builder.Name, (options) =>
-                {
-                    options.HttpMessageHandlerBuilderActions.Add(b => b.PrimaryHandler = configureHandler(services));
-                });
+                options.HttpMessageHandlerBuilderActions.Add(b => b.PrimaryHandler = configureHandler(b.Services));
             });
 
             return builder;
@@ -229,6 +242,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="THandler">
         /// The type of the <see cref="DelegatingHandler"/>. The handler type must be registered as a transient service.
         /// </typeparam>
+        /// <remarks>
+        /// <para>
+        /// The <typeparamref name="THandler"/> will be resolved from a scoped service provider that shares 
+        /// the lifetime of the handler being constructed.
+        /// </para>
+        /// </remarks>
         public static IHttpClientBuilder ConfigurePrimaryHttpMessageHandler<THandler>(this IHttpClientBuilder builder)
             where THandler : HttpMessageHandler
         {
@@ -237,12 +256,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.Services.AddTransient<IConfigureOptions<HttpClientFactoryOptions>>(services =>
+            builder.Services.Configure<HttpClientFactoryOptions>(options =>
             {
-                return new ConfigureNamedOptions<HttpClientFactoryOptions>(builder.Name, (options) =>
-                {
-                    options.HttpMessageHandlerBuilderActions.Add(b => b.PrimaryHandler = services.GetRequiredService<THandler>());
-                });
+                options.HttpMessageHandlerBuilderActions.Add(b => b.PrimaryHandler = b.Services.GetRequiredService<THandler>());
             });
 
             return builder;
@@ -291,6 +307,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Calling <see cref="HttpClientBuilderExtensions.AddTypedClient{TClient}(IHttpClientBuilder)"/> will register a typed
         /// client binding that creates <typeparamref name="TClient"/> using the <see cref="ITypedHttpClientFactory{TClient}" />.
         /// </para>
+        /// <para>
+        /// The typed client's service dependencies will be resolved from the same service provider
+        /// that is used to resolve the typed client. It is not possible to access services from the
+        /// scope bound to the message handler, which is managed independently.
+        /// </para>
         /// </remarks>
         public static IHttpClientBuilder AddTypedClient<TClient>(this IHttpClientBuilder builder)
             where TClient : class
@@ -336,6 +357,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Calling <see cref="HttpClientBuilderExtensions.AddTypedClient{TClient,TImplementation}(IHttpClientBuilder)"/>
         /// will register a typed client binding that creates <typeparamref name="TImplementation"/> using the 
         /// <see cref="ITypedHttpClientFactory{TImplementation}" />.
+        /// </para>
+        /// <para>
+        /// The typed client's service dependencies will be resolved from the same service provider
+        /// that is used to resolve the typed client. It is not possible to access services from the
+        /// scope bound to the message handler, which is managed independently.
         /// </para>
         /// </remarks>
         public static IHttpClientBuilder AddTypedClient<TClient, TImplementation>(this IHttpClientBuilder builder)

--- a/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Typed Clients
             //
             services.TryAdd(ServiceDescriptor.Transient(typeof(ITypedHttpClientFactory<>), typeof(DefaultTypedHttpClientFactory<>)));
+            services.TryAdd(ServiceDescriptor.Transient(typeof(DefaultTypedHttpClientFactory<>.Cache), typeof(DefaultTypedHttpClientFactory<>.Cache)));
 
             //
             // Misc infrastructure

--- a/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Http/DependencyInjection/HttpClientFactoryServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
             //
             // Typed Clients
             //
-            services.TryAdd(ServiceDescriptor.Singleton(typeof(ITypedHttpClientFactory<>), typeof(DefaultTypedHttpClientFactory<>)));
+            services.TryAdd(ServiceDescriptor.Transient(typeof(ITypedHttpClientFactory<>), typeof(DefaultTypedHttpClientFactory<>)));
 
             //
             // Misc infrastructure

--- a/src/Microsoft.Extensions.Http/ExpiredHandlerTrackingEntry.cs
+++ b/src/Microsoft.Extensions.Http/ExpiredHandlerTrackingEntry.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Http
 {
@@ -11,9 +12,12 @@ namespace Microsoft.Extensions.Http
     {
         private readonly WeakReference _livenessTracker;
 
+        // IMPORTANT: don't cache a reference to `other` or `other.Handler` here.
+        // We need to allow it to be GC'ed.
         public ExpiredHandlerTrackingEntry(ActiveHandlerTrackingEntry other)
         {
             Name = other.Name;
+            Scope = other.Scope;
 
             _livenessTracker = new WeakReference(other.Handler);
             InnerHandler = other.Handler.InnerHandler;
@@ -24,5 +28,7 @@ namespace Microsoft.Extensions.Http
         public HttpMessageHandler InnerHandler { get; }
 
         public string Name { get; }
+
+        public IServiceScope Scope { get; }
     }
 }

--- a/src/Microsoft.Extensions.Http/HttpClientFactoryOptions.cs
+++ b/src/Microsoft.Extensions.Http/HttpClientFactoryOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Http
 {
@@ -67,5 +68,32 @@ namespace Microsoft.Extensions.Http
                 _handlerLifetime = value;
             }
         }
+
+        /// <summary>
+        /// <para>
+        /// Gets or sets a value that determines whether the <see cref="IHttpClientFactory"/> will
+        /// create a dependency injection scope when building an <see cref="HttpMessageHandler"/>.
+        /// If <c>false</c> (default), a scope will be created, otherwise a scope will not be created.
+        /// </para>
+        /// <para>
+        /// This option is provided for compatibility with existing applications. It is recommended
+        /// to use the default setting for new applications.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="IHttpClientFactory"/> will (by default) create a dependency injection scope
+        /// each time it creates an <see cref="HttpMessageHandler"/>. The created scope has the same
+        /// lifetime as the message handler, and will be disposed when the message handler is disposed.
+        /// </para>
+        /// <para>
+        /// When operations that are part of <see cref="HttpMessageHandlerBuilderActions"/> are executed
+        /// they will be provided with the scoped <see cref="IServiceProvider"/> via 
+        /// <see cref="HttpMessageHandlerBuilder.Services"/>. This includes retrieving a message handler
+        /// from dependency injection, such as one registered using 
+        /// <see cref="HttpClientBuilderExtensions.AddHttpMessageHandler{THandler}(IHttpClientBuilder)"/>.
+        /// </para>
+        /// </remarks>
+        public bool SuppressHandlerScope { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Http/HttpMessageHandlerBuilder.cs
+++ b/src/Microsoft.Extensions.Http/HttpMessageHandlerBuilder.cs
@@ -40,6 +40,19 @@ namespace Microsoft.Extensions.Http
         public abstract IList<DelegatingHandler> AdditionalHandlers { get; }
 
         /// <summary>
+        /// Gets an <see cref="IServiceProvider"/> which can be used to resolve services
+        /// from the dependency injection container.
+        /// </summary>
+        /// <remarks>
+        /// This property is sensitive to the value of 
+        /// <see cref="HttpClientFactoryOptions.SuppressHandlerScope"/>. If <c>true</c> this
+        /// property will be a reference to the application's root service provider. If <c>false</c>
+        /// (default) this will be a reference to a scoped service provider that has the same
+        /// lifetime as the handler being created.
+        /// </remarks>
+        public virtual IServiceProvider Services { get; }
+
+        /// <summary>
         /// Creates an <see cref="HttpMessageHandler"/>.
         /// </summary>
         /// <returns>

--- a/test/Microsoft.Extensions.Http.Test/DefaultHttpClientFactoryTest.cs
+++ b/test/Microsoft.Extensions.Http.Test/DefaultHttpClientFactoryTest.cs
@@ -21,10 +21,13 @@ namespace Microsoft.Extensions.Http
         public DefaultHttpClientFactoryTest()
         {
             Services = new ServiceCollection().AddHttpClient().BuildServiceProvider();
+            ScopeFactory = Services.GetRequiredService<IServiceScopeFactory>();
             Options = Services.GetRequiredService<IOptionsMonitor<HttpClientFactoryOptions>>();
         }
 
         public IServiceProvider Services { get; }
+
+        public IServiceScopeFactory ScopeFactory { get; }
 
         public ILoggerFactory LoggerFactory { get; } = NullLoggerFactory.Instance;
 
@@ -42,7 +45,7 @@ namespace Microsoft.Extensions.Http
                 count++;
             });
 
-            var factory = new TestHttpClientFactory(Services, LoggerFactory, Options, EmptyFilters);
+            var factory = new TestHttpClientFactory(Services, ScopeFactory, LoggerFactory, Options, EmptyFilters);
 
             // Act 1
             var client1 = factory.CreateClient();
@@ -65,7 +68,7 @@ namespace Microsoft.Extensions.Http
                 count++;
             });
 
-            var factory = new TestHttpClientFactory(Services, LoggerFactory, Options, EmptyFilters);
+            var factory = new TestHttpClientFactory(Services, ScopeFactory, LoggerFactory, Options, EmptyFilters);
 
             // Act 1
             var client1 = factory.CreateClient();
@@ -93,7 +96,7 @@ namespace Microsoft.Extensions.Http
                 b.PrimaryHandler = mockHandler.Object;
             });
 
-            var factory = new TestHttpClientFactory(Services, LoggerFactory, Options, EmptyFilters);
+            var factory = new TestHttpClientFactory(Services, ScopeFactory, LoggerFactory, Options, EmptyFilters);
 
             // Act 
             using (factory.CreateClient())
@@ -113,7 +116,7 @@ namespace Microsoft.Extensions.Http
                 count++;
             });
 
-            var factory = new TestHttpClientFactory(Services, LoggerFactory, Options, EmptyFilters);
+            var factory = new TestHttpClientFactory(Services, ScopeFactory, LoggerFactory, Options, EmptyFilters);
 
             // Act
             var client = factory.CreateClient();
@@ -132,7 +135,7 @@ namespace Microsoft.Extensions.Http
                 count++;
             });
 
-            var factory = new TestHttpClientFactory(Services, LoggerFactory, Options, EmptyFilters);
+            var factory = new TestHttpClientFactory(Services, ScopeFactory, LoggerFactory, Options, EmptyFilters);
 
             // Act
             var client = factory.CreateClient("github");
@@ -195,7 +198,7 @@ namespace Microsoft.Extensions.Http
                     b.AdditionalHandlers.Add((DelegatingHandler)expected[4]);
                 });
 
-            var factory = new TestHttpClientFactory(Services, LoggerFactory, Options, new[]
+            var factory = new TestHttpClientFactory(Services, ScopeFactory, LoggerFactory, Options, new[]
             {
                 filter1.Object,
                 filter2.Object,
@@ -224,7 +227,7 @@ namespace Microsoft.Extensions.Http
         public async Task Factory_CreateClient_WithExpiry_CanExpire()
         {
             // Arrange
-            var factory = new TestHttpClientFactory(Services, LoggerFactory, Options, EmptyFilters)
+            var factory = new TestHttpClientFactory(Services, ScopeFactory, LoggerFactory, Options, EmptyFilters)
             {
                 EnableExpiryTimer = true,
                 EnableCleanupTimer = true,
@@ -267,7 +270,7 @@ namespace Microsoft.Extensions.Http
         public async Task Factory_CreateClient_WithExpiry_HandlerCanBeReusedBeforeExpiry()
         {
             // Arrange
-            var factory = new TestHttpClientFactory(Services, LoggerFactory, Options, EmptyFilters)
+            var factory = new TestHttpClientFactory(Services, ScopeFactory, LoggerFactory, Options, EmptyFilters)
             {
                 EnableExpiryTimer = true,
                 EnableCleanupTimer = true,
@@ -322,7 +325,7 @@ namespace Microsoft.Extensions.Http
                 b.AdditionalHandlers.Add(disposeHandler);
             });
 
-            var factory = new TestHttpClientFactory(Services, LoggerFactory, Options, EmptyFilters)
+            var factory = new TestHttpClientFactory(Services, ScopeFactory, LoggerFactory, Options, EmptyFilters)
             {
                 EnableExpiryTimer = true,
                 EnableCleanupTimer = true,
@@ -369,7 +372,7 @@ namespace Microsoft.Extensions.Http
                 b.AdditionalHandlers.Add(disposeHandler);
             });
 
-            var factory = new TestHttpClientFactory(Services, LoggerFactory, Options, EmptyFilters)
+            var factory = new TestHttpClientFactory(Services, ScopeFactory, LoggerFactory, Options, EmptyFilters)
             {
                 EnableExpiryTimer = true,
                 EnableCleanupTimer = true,
@@ -451,10 +454,11 @@ namespace Microsoft.Extensions.Http
         {
             public TestHttpClientFactory(
                 IServiceProvider services,
+                IServiceScopeFactory scopeFactory,
                 ILoggerFactory loggerFactory,
                 IOptionsMonitor<HttpClientFactoryOptions> optionsMonitor,
                 IEnumerable<IHttpMessageHandlerBuilderFilter> filters)
-                : base(services, loggerFactory, optionsMonitor, filters)
+                : base(services, scopeFactory, loggerFactory, optionsMonitor, filters)
             {
                 ActiveEntryState = new Dictionary<ActiveHandlerTrackingEntry, (TaskCompletionSource<ActiveHandlerTrackingEntry>, Task)>();
                 CleanupTimerStarted = new ManualResetEventSlim(initialState: false);

--- a/test/Microsoft.Extensions.Http.Test/DefaultHttpMessageHandlerBuilderTest.cs
+++ b/test/Microsoft.Extensions.Http.Test/DefaultHttpMessageHandlerBuilderTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
@@ -10,6 +11,13 @@ namespace Microsoft.Extensions.Http
 {
     public class DefaultHttpMessageHandlerBuilderTest
     {
+        public DefaultHttpMessageHandlerBuilderTest()
+        {
+            Services = new ServiceCollection().BuildServiceProvider();
+        }
+
+        public IServiceProvider Services { get; }
+
         // Testing this because it's an important design detail. If someone wants to globally replace the handler
         // they can do so by replacing this service. It's important that the Factory isn't the one to instantiate
         // the handler. The factory has no defaults - it only applies options.
@@ -17,7 +25,7 @@ namespace Microsoft.Extensions.Http
         public void Ctor_SetsPrimaryHandler()
         {
             // Arrange & Act
-            var builder = new DefaultHttpMessageHandlerBuilder();
+            var builder = new DefaultHttpMessageHandlerBuilder(Services);
 
             // Act
             Assert.IsType<HttpClientHandler>(builder.PrimaryHandler);
@@ -28,7 +36,7 @@ namespace Microsoft.Extensions.Http
         public void Build_NoAdditionalHandlers_ReturnsPrimaryHandler()
         {
             // Arrange
-            var builder = new DefaultHttpMessageHandlerBuilder()
+            var builder = new DefaultHttpMessageHandlerBuilder(Services)
             {
                 PrimaryHandler = Mock.Of<HttpMessageHandler>(),
             };
@@ -44,7 +52,7 @@ namespace Microsoft.Extensions.Http
         public void Build_SomeAdditionalHandlers_PutsTogetherDelegatingHandlers()
         {
             // Arrange
-            var builder = new DefaultHttpMessageHandlerBuilder()
+            var builder = new DefaultHttpMessageHandlerBuilder(Services)
             {
                 PrimaryHandler = Mock.Of<HttpMessageHandler>(),
                 AdditionalHandlers =
@@ -71,7 +79,7 @@ namespace Microsoft.Extensions.Http
         public void Build_PrimaryHandlerIsNull_ThrowsException()
         {
             // Arrange
-            var builder = new DefaultHttpMessageHandlerBuilder()
+            var builder = new DefaultHttpMessageHandlerBuilder(Services)
             {
                 PrimaryHandler = null,
             };
@@ -85,7 +93,7 @@ namespace Microsoft.Extensions.Http
         public void Build_AdditionalHandlerIsNull_ThrowsException()
         {
             // Arrange
-            var builder = new DefaultHttpMessageHandlerBuilder()
+            var builder = new DefaultHttpMessageHandlerBuilder(Services)
             {
                 AdditionalHandlers =
                 {
@@ -102,7 +110,7 @@ namespace Microsoft.Extensions.Http
         public void Build_AdditionalHandlerHasNonNullInnerHandler_ThrowsException()
         {
             // Arrange
-            var builder = new DefaultHttpMessageHandlerBuilder()
+            var builder = new DefaultHttpMessageHandlerBuilder(Services)
             {
                 AdditionalHandlers =
                 {

--- a/test/Microsoft.Extensions.Http.Test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Http.Test/DependencyInjection/HttpClientFactoryServiceCollectionExtensionsTest.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Http.Logging;
 using Microsoft.Extensions.Options;
@@ -516,12 +518,412 @@ namespace Microsoft.Extensions.DependencyInjection
             Assert.Equal("http://example.com/", client.HttpClient.BaseAddress.AbsoluteUri);
         }
 
+        [Fact]
+        public async Task AddHttpClient_MessageHandler_SingletonDependency()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<SingletonService>();
+            serviceCollection.AddTransient<HandlerWithSingletonService>();
+            serviceCollection
+                .AddHttpClient<TypedClientWithSingletonService>("test")
+                .AddHttpMessageHandler<HandlerWithSingletonService>();
+
+            var services = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            // Act
+            var client = services.GetRequiredService<TypedClientWithSingletonService>();
+
+            // Assert
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/");
+            var response = await client.HttpClient.SendAsync(request);
+
+            Assert.Same(
+                services.GetRequiredService<SingletonService>(),
+                request.Properties[nameof(SingletonService)]);
+
+            Assert.Same(
+                client.Service,
+                request.Properties[nameof(SingletonService)]);
+        }
+
+        [Fact]
+        public async Task AddHttpClient_MessageHandler_Scope_SingletonDependency()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<SingletonService>();
+            serviceCollection.AddTransient<HandlerWithSingletonService>();
+            serviceCollection
+                .AddHttpClient<TypedClientWithSingletonService>("test")
+                .AddHttpMessageHandler<HandlerWithSingletonService>();
+
+            var services = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            using (var scope = services.GetRequiredService<IServiceScopeFactory>().CreateScope())
+            {
+                // Act
+                var client = scope.ServiceProvider.GetRequiredService<TypedClientWithSingletonService>();
+
+                // Assert
+                var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/");
+                var response = await client.HttpClient.SendAsync(request);
+
+                Assert.Same(
+                    services.GetRequiredService<SingletonService>(),
+                    request.Properties[nameof(SingletonService)]);
+
+                Assert.Same(
+                    scope.ServiceProvider.GetRequiredService<SingletonService>(),
+                    request.Properties[nameof(SingletonService)]);
+
+                Assert.Same(
+                    client.Service,
+                    request.Properties[nameof(SingletonService)]);
+            }
+        }
+
+        [Fact]
+        public void AddHttpClient_MessageHandler_ScopedDependency()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddScoped<ScopedService>();
+            serviceCollection.AddTransient<HandlerWithScopedService>();
+            serviceCollection
+                .AddHttpClient<TypedClientWithScopedService>("test")
+                .AddHttpMessageHandler<HandlerWithScopedService>();
+
+            var services = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                services.GetRequiredService<TypedClientWithScopedService>();
+            });
+        }
+
+        [Fact]
+        public async Task AddHttpClient_MessageHandler_Scope_ScopedDependency()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddScoped<ScopedService>();
+            serviceCollection.AddScoped<HandlerWithScopedService>();
+            serviceCollection
+                .AddHttpClient<TypedClientWithScopedService>("test")
+                .AddHttpMessageHandler<HandlerWithScopedService>();
+
+            var services = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            using (var scope = services.GetRequiredService<IServiceScopeFactory>().CreateScope())
+            {
+                // Act
+                var client = scope.ServiceProvider.GetRequiredService<TypedClientWithScopedService>();
+
+                // Assert
+                var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/");
+                var response = await client.HttpClient.SendAsync(request);
+
+                Assert.NotSame(
+                    scope.ServiceProvider.GetRequiredService<ScopedService>(),
+                    request.Properties[nameof(ScopedService)]);
+
+                Assert.Same(
+                    scope.ServiceProvider.GetRequiredService<ScopedService>(),
+                    client.Service);
+
+                Assert.NotSame(
+                    client.Service,
+                    request.Properties[nameof(ScopedService)]);
+            }
+        }
+
+        [Fact]
+        public async Task AddHttpClient_MessageHandler_TransientDependency()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<TransientService>();
+            serviceCollection.AddTransient<HandlerWithTransientService>();
+            serviceCollection
+                .AddHttpClient<TypedClientWithTransientService>("test")
+                .AddHttpMessageHandler<HandlerWithTransientService>();
+
+            var services = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            // Act
+            var client = services.GetRequiredService<TypedClientWithTransientService>();
+
+            // Assert
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/");
+            var response = await client.HttpClient.SendAsync(request);
+
+            Assert.NotSame(
+                services.GetRequiredService<TransientService>(),
+                request.Properties[nameof(TransientService)]);
+
+            Assert.NotSame(
+                client.Service,
+                request.Properties[nameof(TransientService)]);
+        }
+
+        [Fact]
+        public async Task AddHttpClient_MessageHandler_Scope_TransientDependency()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<TransientService>();
+            serviceCollection.AddTransient<HandlerWithTransientService>();
+            serviceCollection
+                .AddHttpClient<TypedClientWithTransientService>("test")
+                .AddHttpMessageHandler<HandlerWithTransientService>();
+
+            var services = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            using (var scope = services.GetRequiredService<IServiceScopeFactory>().CreateScope())
+            {
+                // Act
+                var client = scope.ServiceProvider.GetRequiredService<TypedClientWithTransientService>();
+
+                // Assert
+                var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/");
+                var response = await client.HttpClient.SendAsync(request);
+
+                Assert.NotSame(
+                    services.GetRequiredService<TransientService>(),
+                    request.Properties[nameof(TransientService)]);
+
+                Assert.NotSame(
+                    client.Service,
+                    request.Properties[nameof(TransientService)]);
+            }
+        }
+
+        [Fact]
+        public void SuppressScope_False_CreatesNewScope()
+        {
+            // Arrange
+            IServiceProvider capturedServices = null;
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection
+                .AddHttpClient<TestTypedClient>("test")
+                .AddHttpMessageHandler(s =>
+                {
+                    capturedServices = s;
+                    return Mock.Of<DelegatingHandler>();
+                });
+
+            serviceCollection.Configure<HttpClientFactoryOptions>("test", o =>
+            {
+                o.SuppressHandlerScope = false;
+            });
+
+            var services = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            // Act
+            services.GetRequiredService<TestTypedClient>();
+
+            Assert.NotSame(services, capturedServices);
+        }
+
+        [Fact]
+        public void SuppressScope_False_InScope_CreatesNewScope()
+        {
+            // Arrange
+            IServiceProvider capturedServices = null;
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection
+                .AddHttpClient<TestTypedClient>("test")
+                .AddHttpMessageHandler(s =>
+                {
+                    capturedServices = s;
+                    return Mock.Of<DelegatingHandler>();
+                });
+
+            serviceCollection.Configure<HttpClientFactoryOptions>("test", o =>
+            {
+                o.SuppressHandlerScope = false;
+            });
+
+            var services = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            using (var scope = services.GetRequiredService<IServiceScopeFactory>().CreateScope())
+            {
+                // Act
+                scope.ServiceProvider.GetRequiredService<TestTypedClient>();
+
+                Assert.NotSame(services, capturedServices);
+                Assert.NotSame(scope.ServiceProvider, capturedServices);
+            }
+        }
+
+        [Fact]
+        public void SuppressScope_True_DoesNotCreateScope()
+        {
+            // Arrange
+            IServiceProvider capturedServices = null;
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection
+                .AddHttpClient<TestTypedClient>("test")
+                .AddHttpMessageHandler(s =>
+                {
+                    capturedServices = s;
+                    return Mock.Of<DelegatingHandler>();
+                });
+
+            serviceCollection.Configure<HttpClientFactoryOptions>("test", o =>
+            {
+                o.SuppressHandlerScope = true;
+            });
+
+            var services = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            // Act
+            services.GetRequiredService<TestTypedClient>();
+
+            Assert.NotSame(services, capturedServices);
+        }
+
+        [Fact]
+        public void SuppressScope_True_InScope_DoesNotCreateScope()
+        {
+            // Arrange
+            IServiceProvider capturedServices = null;
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection
+                .AddHttpClient<TestTypedClient>("test")
+                .AddHttpMessageHandler(s =>
+                {
+                    capturedServices = s;
+                    return Mock.Of<DelegatingHandler>();
+                });
+
+            serviceCollection.Configure<HttpClientFactoryOptions>("test", o =>
+            {
+                o.SuppressHandlerScope = true;
+            });
+
+            var services = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            using (var scope = services.GetRequiredService<IServiceScopeFactory>().CreateScope())
+            {
+                // Act
+                scope.ServiceProvider.GetRequiredService<TestTypedClient>();
+
+                Assert.NotSame(scope.ServiceProvider, capturedServices);
+            }
+        }
+
         private class TestGenericTypedClient<T> : TestTypedClient
         {
             public TestGenericTypedClient(HttpClient httpClient)
                 : base(httpClient)
             {
             }
+        }
+
+        private class SingletonService
+        {
+        }
+
+        private class ScopedService
+        {
+        }
+
+        private class TransientService
+        {
+        }
+
+        private class HandlerWithSingletonService : DelegatingHandler
+        {
+            public HandlerWithSingletonService(SingletonService service)
+            {
+                Service = service;
+            }
+
+            public SingletonService Service { get; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                request.Properties[nameof(SingletonService)] = Service;
+                return Task.FromResult(new HttpResponseMessage());
+            }
+        }
+
+        private class HandlerWithScopedService : DelegatingHandler
+        {
+            public HandlerWithScopedService(ScopedService service)
+            {
+                Service = service;
+            }
+
+            public ScopedService Service { get; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                request.Properties[nameof(ScopedService)] = Service;
+                return Task.FromResult(new HttpResponseMessage());
+            }
+        }
+
+        private class HandlerWithTransientService : DelegatingHandler
+        {
+            public HandlerWithTransientService(TransientService service)
+            {
+                Service = service;
+            }
+
+            public TransientService Service { get; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                request.Properties[nameof(TransientService)] = Service;
+                return Task.FromResult(new HttpResponseMessage());
+            }
+        }
+
+        private class TypedClientWithSingletonService
+        {
+            public TypedClientWithSingletonService(HttpClient httpClient, SingletonService service)
+            {
+                HttpClient = httpClient;
+                Service = service;
+            }
+
+            public HttpClient HttpClient { get; }
+
+            public SingletonService Service { get; }
+        }
+
+        private class TypedClientWithScopedService
+        {
+            public TypedClientWithScopedService(HttpClient httpClient, ScopedService service)
+            {
+                HttpClient = httpClient;
+                Service = service;
+            }
+
+            public HttpClient HttpClient { get; }
+
+            public ScopedService Service { get; }
+        }
+
+        private class TypedClientWithTransientService
+        {
+            public TypedClientWithTransientService(HttpClient httpClient, TransientService service)
+            {
+                HttpClient = httpClient;
+                Service = service;
+            }
+
+            public HttpClient HttpClient { get; }
+
+            public TransientService Service { get; }
         }
     }
 }


### PR DESCRIPTION
This is a rework of the http client factory interacts with dependency
injection when creating a message handler. Since the http client factory
manages the lifetimes of message handlers, it's not appropriate for a
message handler and related services to share lifetimes with the
application or 'current request' scope.

Now the factory creates a scope each time it creates a handler, and then
disposes the scope when the handler is disposed. This allows the handler
building process to resolve scoped services and also to prevent
allocating lots and lots of disposable transients in the application
global scope.

The fix for #134 also required a rework of some details of
`DefaultTypedClientFactory<>`.